### PR TITLE
Corrected a copy-paste error in the description

### DIFF
--- a/draftwatermark.dtx
+++ b/draftwatermark.dtx
@@ -245,8 +245,8 @@
 %   Defines the horizontal position of the watermark anchor
 %   point. Specifically, |l| stands for \emph{left}, |c| for \emph{center}
 %   and |r| for \emph{right}. See also the |anchor| option.
-% \item \verb!hanchor=t|m|b!\\
-%   Default is |c|.\\
+% \item \verb!vanchor=t|m|b!\\
+%   Default is |m|.\\
 %   Defines the vertical position of the watermark anchor
 %   point. Specifically, |t| stands for \emph{top}, |m| for \emph{middle}
 %   and |b| for \emph{bottom}. See also the |anchor| option.


### PR DESCRIPTION
hanchor was a duplicate. Changed it to vanchor and corrected the default value